### PR TITLE
Added link to MQTT plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ or manually using this URL:
 
     https://github.com/cmroche/OctoPrint-HomeAsisstant/archive/master.zip
 
-You will also need the OctoPrint-MQTT plugin installed and configured to connected to your Home Assistant MQTT service, and MQTT discovery enabled (should be the default). With these, by using the OctoPrint-HomeAssistant plugin your OctoPrint instance will automatically register a device and several sensors to follow your printer status, printing and slicing progress.
+You will also need the [OctoPrint-MQTT plugin](https://github.com/OctoPrint/OctoPrint-MQTT) installed and configured to connected to your Home Assistant MQTT service, and MQTT discovery enabled (should be the default). With these, by using the OctoPrint-HomeAssistant plugin your OctoPrint instance will automatically register a device and several sensors to follow your printer status, printing and slicing progress.
 
 ***NOTE*** OctoPrint-MQTT works best with HomeAssistant if you leave the default "retain" option enabled. Remember to restart OctoPrint after configuring your MQTT broker settings or installing OctoPrint-HomeAssistant to properly register.
 


### PR DESCRIPTION
I was a bit confused about which MQTT plugin exactly was required, as there are a few with MQTT in their names. The link should make it clear to the users.