### PR TITLE
Better progress sensors

### DIFF
--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -38,6 +38,7 @@ MQTT_DEFAULTS = dict(
 class HomeassistantPlugin(octoprint.plugin.SettingsPlugin,
 						  octoprint.plugin.TemplatePlugin,
 						  octoprint.plugin.StartupPlugin,
+                          octoprint.plugin.EventHandlerPlugin,
 						  octoprint.plugin.ProgressPlugin,
 						  octoprint.plugin.WizardPlugin):
 
@@ -306,6 +307,16 @@ class HomeassistantPlugin(octoprint.plugin.SettingsPlugin,
 
 		##~~ Setup the default printer states
 		self.on_print_progress("", "", 0)
+
+	##~~ EventHandlerPlugin API
+
+	def on_event(self, event, payload):
+		if event in (Events.PRINT_STARTED, Events.FILE_SELECTED, Events.PRINT_CANCELLING, Events.PRINT_FAILED):
+			self.on_print_progress(payload["origin"], payload["path"], 0)
+		elif event == Events.PRINT_DONE:
+			self.on_print_progress(payload["origin"], payload["path"], 100)
+		elif event in (Events.FILE_DESELECTED, Events.CONNECTING, Events.ERROR, Events.DISCONNECTED):
+			self.on_print_progress("", "", 0)
 
 	##~~ ProgressPlugin API
 

--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -247,6 +247,7 @@ class HomeassistantPlugin(octoprint.plugin.SettingsPlugin,
 			"pl_not_avail": "disconnected",
 			"val_tpl": "{{value_json.path}}",
 			"device": _config_device,
+			"ic": "mdi:file",
 			"~": self._generate_topic("baseTopic", "", full=True)
 		}
 
@@ -320,6 +321,7 @@ class HomeassistantPlugin(octoprint.plugin.SettingsPlugin,
 			"unit_of_meas": "mm",
 			"val_tpl": "{{value_json.currentZ|float}}",
 			"device": _config_device,
+			"ic": "mdi:printer-3d-nozzle",
 			"~": self._generate_topic("baseTopic", "", full=True)
 		}
 
@@ -357,6 +359,7 @@ class HomeassistantPlugin(octoprint.plugin.SettingsPlugin,
 			"pl_not_avail": "disconnected",
 			"val_tpl": "{{value_json.source_path}}",
 			"device": _config_device,
+			"ic": "mdi:file",
 			"~": self._generate_topic("baseTopic", "", full=True)
 		}
 

--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -61,7 +61,7 @@ class HomeassistantPlugin(octoprint.plugin.SettingsPlugin,
 	##~~ StartupPlugin mixin
 
 	def on_startup(self, host, port):
-		self._logger.setLevel(logging.DEBUG)
+		self._logger.setLevel(logging.INFO)
 
 	def on_after_startup(self):
 		if self._settings.get(["unique_id"]) is None:


### PR DESCRIPTION
This changes fixes a few issues with the reliability of the progress sensor, by better detecting and managing printer states.

In addition, sensors for print time, and print time left are now available. The values are updated approximately every 30 seconds.

Addresses #7 