### PR TITLE
Add discovery_topic to config

### DIFF
--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -542,6 +542,8 @@ class HomeassistantPlugin(
 
         _config_device = self._generate_device_config(_node_id, _node_name)
 
+        _discovery_topic = self._settings.get(["discovery_topic"])
+
         # Emergency stop
         if subscribe:
             self.mqtt_subscribe(

--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -24,7 +24,11 @@ from octoprint.util import RepeatedTimer
 # Take a look at the documentation on what other plugin mixins are available.
 
 
-SETTINGS_DEFAULTS = dict(unique_id=None, node_id=None)
+SETTINGS_DEFAULTS = dict(
+    unique_id=None,
+    node_id=None,
+    discovery_topic="homeassistant"
+)
 MQTT_DEFAULTS = dict(
     publish=dict(
         baseTopic="octoPrint/",
@@ -183,12 +187,13 @@ class HomeassistantPlugin(
 
         _node_name = s.get(["appearance", "name"], defaults=name_defaults)
         _node_id = self._settings.get(["node_id"])
+        _discovery_topic = self._settings.get(["discovery_topic"])
 
         _config_device = self._generate_device_config(_node_id, _node_name)
 
         ##~~ Configure Connected Sensor
         self._generate_sensor(
-            topic="homeassistant/binary_sensor/" + _node_id + "_CONNECTED/config",
+            topic = _discovery_topic + "/binary_sensor/" + _node_id + "_CONNECTED/config",
             values={
                 "name": _node_name + " Connected",
                 "uniq_id": _node_id + "_CONNECTED",
@@ -204,7 +209,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Printing Sensor
         self._generate_sensor(
-            topic="homeassistant/binary_sensor/" + _node_id + "_PRINTING/config",
+            topic = _discovery_topic + "/binary_sensor/" + _node_id + "_PRINTING/config",
             values={
                 "name": _node_name + " Printing",
                 "uniq_id": _node_id + "_PRINTING",
@@ -218,7 +223,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Last Event Sensor
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_EVENT/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_EVENT/config",
             values={
                 "name": _node_name + " Last Event",
                 "uniq_id": _node_id + "_EVENT",
@@ -230,7 +235,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Print Status
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_PRINTING_S/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_PRINTING_S/config",
             values={
                 "name": _node_name + " Print Status",
                 "uniq_id": _node_id + "_PRINTING_S",
@@ -244,7 +249,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Print Progress
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_PRINTING_P/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_PRINTING_P/config",
             values={
                 "name": _node_name + " Print Progress",
                 "uniq_id": _node_id + "_PRINTING_P",
@@ -257,7 +262,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Print File
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_PRINTING_F/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_PRINTING_F/config",
             values={
                 "name": _node_name + " Print File",
                 "uniq_id": _node_id + "_PRINTING_F",
@@ -270,7 +275,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Print Time
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_PRINTING_T/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_PRINTING_T/config",
             values={
                 "name": _node_name + " Print Time",
                 "uniq_id": _node_id + "_PRINTING_T",
@@ -283,7 +288,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Print Time Left
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_PRINTING_E/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_PRINTING_E/config",
             values={
                 "name": _node_name + " Print Time Left",
                 "uniq_id": _node_id + "_PRINTING_E",
@@ -296,7 +301,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Print ETA
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_PRINTING_ETA/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_PRINTING_ETA/config",
             values={
                 "name": _node_name + " Print Estimated Time",
                 "uniq_id": _node_id + "_PRINTING_ETA",
@@ -310,7 +315,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Print Current Z
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_PRINTING_Z/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_PRINTING_Z/config",
             values={
                 "name": _node_name + " Current Z",
                 "uniq_id": _node_id + "_PRINTING_Z",
@@ -324,7 +329,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Slicing Status
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_SLICING_P/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_SLICING_P/config",
             values={
                 "name": _node_name + " Slicing Progress",
                 "uniq_id": _node_id + "_SLICING_P",
@@ -337,7 +342,7 @@ class HomeassistantPlugin(
 
         ##~~ Configure Slicing File
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_SLICING_F/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_SLICING_F/config",
             values={
                 "name": _node_name + " Slicing File",
                 "uniq_id": _node_id + "_SLICING_F",
@@ -352,7 +357,7 @@ class HomeassistantPlugin(
         _e = self._printer_profile_manager.get_current_or_default()["extruder"]["count"]
         for x in range(_e):
             self._generate_sensor(
-                topic="homeassistant/sensor/" + _node_id + "_TOOL" + str(x) + "/config",
+                topic = _discovery_topic + "/sensor/" + _node_id + "_TOOL" + str(x) + "/config",
                 values={
                     "name": _node_name + " Tool " + str(x) + " Temperature",
                     "uniq_id": _node_id + "_TOOL" + str(x),
@@ -366,7 +371,7 @@ class HomeassistantPlugin(
                 },
             )
             self._generate_sensor(
-                topic="homeassistant/sensor/"
+                topic = _discovery_topic + "/sensor/"
                 + _node_id
                 + "_TOOL_TARGET"
                 + str(x)
@@ -386,7 +391,7 @@ class HomeassistantPlugin(
 
         ##~~ Bed Temperature
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_BED/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_BED/config",
             values={
                 "name": _node_name + " Bed Temperature",
                 "uniq_id": _node_id + "_BED",
@@ -399,7 +404,7 @@ class HomeassistantPlugin(
             },
         )
         self._generate_sensor(
-            topic="homeassistant/sensor/" + _node_id + "_BED_TARGET/config",
+            topic = _discovery_topic + "/sensor/" + _node_id + "_BED_TARGET/config",
             values={
                 "name": _node_name + " Bed Target",
                 "uniq_id": _node_id + "_BED_TARGET",
@@ -545,7 +550,7 @@ class HomeassistantPlugin(
             )
 
         self._generate_sensor(
-            topic="homeassistant/switch/" + _node_id + "_STOP/config",
+            topic = _discovery_topic + "/switch/" + _node_id + "_STOP/config",
             values={
                 "name": _node_name + " Emergency Stop",
                 "uniq_id": _node_id + "_STOP",
@@ -567,7 +572,7 @@ class HomeassistantPlugin(
             )
 
         self._generate_sensor(
-            topic="homeassistant/switch/" + _node_id + "_CANCEL/config",
+            topic = _discovery_topic + "/switch/" + _node_id + "_CANCEL/config",
             values={
                 "name": _node_name + " Cancel Print",
                 "uniq_id": _node_id + "_CANCEL",
@@ -592,7 +597,7 @@ class HomeassistantPlugin(
             )
 
         self._generate_sensor(
-            topic="homeassistant/switch/" + _node_id + "_PAUSE/config",
+            topic = _discovery_topic + "/switch/" + _node_id + "_PAUSE/config",
             values={
                 "name": _node_name + " Pause Print",
                 "uniq_id": _node_id + "_PAUSE",
@@ -616,7 +621,7 @@ class HomeassistantPlugin(
             )
 
         self._generate_sensor(
-            topic="homeassistant/switch/" + _node_id + "_SHUTDOWN/config",
+            topic = _discovery_topic + "/switch/" + _node_id + "_SHUTDOWN/config",
             values={
                 "name": _node_name + " Shutdown System",
                 "uniq_id": _node_id + "_SHUTDOWN",


### PR DESCRIPTION
Since I run my HA with a custom topic for discovering MQTT devices, issue #34 sparked my interest. This modification will enable you to customize the topic by adding discovery_topic to config.yaml, with a default setting of 'homeassistant'.