### PR TITLE
Add settings page to OctoPrint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 *.egg*
 .DS_Store
 *.zip
+.vscode

--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -36,6 +36,7 @@ MQTT_DEFAULTS = dict(
     )
 )
 
+
 class HomeassistantPlugin(
     octoprint.plugin.SettingsPlugin,
     octoprint.plugin.TemplatePlugin,
@@ -79,12 +80,7 @@ class HomeassistantPlugin(
     ##~~ TemplatePlugin mixin
 
     def get_template_configs(self):
-        return [
-            dict(
-                type="settings",
-                custom_bindings=False
-            )
-        ]
+        return [dict(type="settings", custom_bindings=False)]
 
     ##~~ StartupPlugin mixin
 
@@ -194,7 +190,9 @@ class HomeassistantPlugin(
         _device_manufacturer = self._settings.get(["device_manufacturer"])
         _device_model = self._settings.get(["device_model"])
 
-        _config_device = self._generate_device_config(_node_id, _node_name, _device_manufacturer, _device_model)
+        _config_device = self._generate_device_config(
+            _node_id, _node_name, _device_manufacturer, _device_model
+        )
 
         ##~~ Configure Connected Sensor
         self._generate_sensor(
@@ -439,7 +437,9 @@ class HomeassistantPlugin(
         payload.update(values)
         self.mqtt_publish(topic, payload, allow_queueing=True)
 
-    def _generate_device_config(self, _node_id, _node_name, _device_manufacturer, _device_model):
+    def _generate_device_config(
+        self, _node_id, _node_name, _device_manufacturer, _device_model
+    ):
         _config_device = {
             "ids": [_node_id],
             "cns": [["mac", self._get_mac_address()]],
@@ -485,15 +485,12 @@ class HomeassistantPlugin(
         state_connected = "Disconnected" if state == "Closed" else "Connected"
         # Function can be called by on_event before on_after_startup has run.
         # This will throw a TypeError since self.mqtt_publish is still null.
-        try:
+        if self.mqtt_publish:
             self.mqtt_publish(
                 self._generate_topic("hassTopic", "Connected", full=True),
                 state_connected,
                 allow_queueing=True,
             )
-        except TypeError:
-            self._logger.warning("mqtt_publish helper is not yet defined, not publishing connection state " + state_connected)
-            pass
 
     def _on_emergency_stop(
         self, topic, message, retained=None, qos=None, *args, **kwargs
@@ -569,7 +566,9 @@ class HomeassistantPlugin(
         _device_manufacturer = self._settings.get(["device_manufacturer"])
         _device_model = self._settings.get(["device_model"])
 
-        _config_device = self._generate_device_config(_node_id, _node_name, _device_manufacturer, _device_model)
+        _config_device = self._generate_device_config(
+            _node_id, _node_name, _device_manufacturer, _device_model
+        )
 
         # Emergency stop
         if subscribe:
@@ -799,8 +798,10 @@ class HomeassistantPlugin(
             )
         )
 
+
 __plugin_name__ = "HomeAssistant Discovery"
 __plugin_pythoncompat__ = ">=2.7,<4"  # python 2 and 3
+
 
 def __plugin_load__():
     global __plugin_implementation__

--- a/octoprint_homeassistant/templates/README.txt
+++ b/octoprint_homeassistant/templates/README.txt
@@ -1,1 +1,0 @@
-Put your plugin's Jinja2 templates here.

--- a/octoprint_homeassistant/templates/homeassistant_settings.jinja2
+++ b/octoprint_homeassistant/templates/homeassistant_settings.jinja2
@@ -1,0 +1,37 @@
+<form id="homeassistant_plugin_settings" class="form-horizontal">
+    <h4>Discovery settings</h4>
+    <div class="accordion-inner">
+        <div class="control-group">
+            <label class="control-label">{{ _('Discovery topic') }}</label>
+            <div class="controls">
+                <input type="text" class="input-block-level" data-bind="value: settings.plugins.homeassistant.discovery_topic">
+            </div>
+            <label class="control-label">{{ _('Node ID') }}</label>
+            <div class="controls">
+                <input type="text" class="input-block-level" data-bind="value: settings.plugins.homeassistant.node_id">
+            </div>
+            <span class="help-block">
+                The id that is used in the MQTT discovery messages.<br/>
+                <br/>
+                <b>Changing this will break existing entities in Home Assistant!</b>
+            </span>
+        </div>
+    </div>
+    <h4>Device settings</h4>
+    <div class="accordion-inner">
+        <div class="control-group">
+            <label class="control-label">{{ _('Device name') }}</label>
+            <div class="controls">
+                <input type="text" class="input-block-level" data-bind="value: settings.plugins.homeassistant.node_name">
+            </div>
+            <label class="control-label">{{ _('Manufacturer') }}</label>
+            <div class="controls">
+                <input type="text" class="input-block-level" data-bind="value: settings.plugins.homeassistant.device_manufacturer">
+            </div>
+            <label class="control-label">{{ _('Model') }}</label>
+            <div class="controls">
+                <input type="text" class="input-block-level" data-bind="value: settings.plugins.homeassistant.device_model">
+            </div>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
This adds a settings page for the plugin to OctoPrint, with the option to set the HA integration name as well as make and model for the device.
Next to that there are some bugfixes, I ran into an error on the generate_connection_status function as it was called by on_event before the MQTT helpers were loaded.
I also changed the name of the nozzle target temperature to TOOLx_TARGET instead of TOOL_TARGETx as that seems more appropriate.