### PR TITLE
Add support for SoC temperatures

### DIFF
--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -448,7 +448,7 @@ class HomeassistantPlugin(
                 "uniq_id": _node_id + "_SOC",
                 "stat_t": "~" + self._generate_topic("temperatureTopic", "soc"),
                 "unit_of_meas": "°C",
-                "val_tpl": "{{value_json.temperature|float}}",
+                "val_tpl": "{{value_json.temperature|float|round(1)}}",
                 "device": _config_device,
                 "dev_cla": "temperature",
                 "ic": "mdi:radiator",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,9 @@ plugin_url = "https://github.com/cmroche/OctoPrint-HomeAssistant"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = []
+plugin_requires = [
+    "psutil"
+]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
This adds a sensor reporting SoC temperatures of the device. It relies on psutil.sensors_temperatures and will work on MOST devices that are linux based, however not yet Windows (and a few others).

Closes #23 