### PR TITLE
Remove mac from device id, uneeded

### DIFF
--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -467,8 +467,7 @@ class HomeassistantPlugin(
         self, _node_id, _node_name, _device_manufacturer, _device_model
     ):
         _config_device = {
-            "ids": [_node_id],
-            "cns": [["mac", self._get_mac_address()]],
+            "ids": _node_id,
             "name": _node_name,
             "mf": _device_manufacturer,
             "mdl": _device_model,


### PR DESCRIPTION
This fixes a potential issue with multi-instance setups where the device instances were all being registered under a single device due to the shared mac address. Since we already use unique identifiers, it shouldn't be required.

#48 