### PR TITLE
Adding speed to jog example

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ tap_action:
   service: mqtt.publish
   service_data:
     topic: octoPrint/hassControl/jog
-    payload: '{"x": 0.1 }'
+    payload: '{"x": 0.1, "speed": 1.0 }'
 ```
 
 #### Send GCODE from Lovelace


### PR DESCRIPTION
I don't know if it's my setup somehow, or if this is a (recent) change in Octoprint, but I couldn't get the `jog` example to work and finally found that I had to add a `"speed": 1.0` (any non-zero value) or the `jog` parameter would instead move the print head to that absolute position.

My setup is OctoPrint 1.4.2 (Python 2.7.16) on a (dedicated) Raspberry Pi 3B

```
octoprint.server - INFO - OctoPrint 1.4.2
octoprint.plugin.core - INFO - 44 plugin(s) registered with the system:
|  Action Command Notification Support (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/action_command_notification
|  Action Command Prompt Support (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/action_command_prompt
|  Announcement Plugin (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/announcements
|  Anonymous Usage Tracking (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/tracking
|  Application Keys Plugin (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/appkeys
| !AstroPrint (1.5.5) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_astroprint
|  Backup & Restore (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/backup
|  Bed Leveling Wizard (0.2.4) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_bedlevelingwizard
|  Change Filament Plugin (0.3.1) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_Change_Filament
|  Core Wizard (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/corewizard
|  Discovery (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/discovery
|  DisplayLayerProgress Plugin (1.24.0) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_DisplayLayerProgress
|  Error Tracking (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/errortracking
|  Filament Manager (1.6.3) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_filamentmanager
|  File Check (2020.8.7) (bundled) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_file_check
|  Firmware Check (2020.9.23) (bundled) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_firmware_check
|  GCode Viewer (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/gcodeviewer
|  HomeAssistant Discovery (3.1.3) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_homeassistant
|  InfluxDB Plugin (1.3.2) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_influxdb
|  Logging (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/logging
|  Login UI (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/loginui
|  Marlin GCode Documentation (0.11.0) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_marlingcodedocumentation
|  MQTT (0.8.7) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_mqtt
|  OctoPod Plugin (0.2.9) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_octopod
|  Pi Support Plugin (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/pi_support
|  Plugin Manager (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/pluginmanager
|  Preheat Button (0.5.1) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_preheat
|  PrintJobHistory (1.10.0) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_PrintJobHistory
|  PrintTimeGenius Plugin (2.2.6) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_PrintTimeGenius
| !Prusa ETA override Plugin (0.1.1) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_PrusaETAOverride
|  PrusaSlicer Thumbnails (0.1.2) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_prusaslicerthumbnails
|  Python 3 Check (0.1.5) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_python3plugincompatibilitycheck
|  Resource Monitor (0.2.6) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_resource_monitor
| !Simple Filament Change Buttons (1.0) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_simple_filament_change_buttons
|  Slic3r (1.2) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_slic3r
|  Slicer (1.4.3) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_slicer
|  SlicerSettingsParser (2.0.1) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_SlicerSettingsParser
|  SlicerSettingsTab (1.0.3) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_SlicerSettingsTab
|  Software Update (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/softwareupdate
|  SpoolManager Plugin (1.2.0) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_SpoolManager
|  STL Viewer (0.4.2) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_stlviewer
|  Tab Order (0.5.11) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_taborder
|  Terminal Messaging (0.1.0) = /home/pi/oprint/local/lib/python2.7/site-packages/octoprint_terminalmessaging
|  Virtual Printer (bundled) = /home/pi/oprint/lib/python2.7/site-packages/octoprint/plugins/virtual_printer
Prefix legend: ! = disabled, # = blacklisted, * = incompatible
octoprint.environment - INFO - Detected environment is Python 2.7.16 under Linux (linux2). Details:
|  hardware:
|      cores: 4
|      freq: 1200.0
|      ram: 916992000
|  os:
|      id: linux
|      platform: linux2
|  plugins:
|      pi_support:
|          model: Raspberry Pi 3 Model B Rev 1.2
|          octopi_version: 0.17.0
|  python:
|      pip: 19.3.1
|      version: 2.7.16
|      virtualenv: /home/pi/oprint
octoprint.server - INFO - ------------------------------------------------------------------------------

``