### PR TITLE
Add PSUControl support

### DIFF
--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -53,6 +53,7 @@ class HomeassistantPlugin(
         self.mqtt_subcribe = None
         self.update_timer = None
         self.constant_timer = None
+        self.psucontrol_enabled = False
 
     def handle_timer(self):
         self._generate_printer_status()
@@ -1025,9 +1026,10 @@ class HomeassistantPlugin(
                 allow_queueing=True,
             )
 
+
         if (
+            self.psucontrol_enabled and 
             event == Events.PLUGIN_PSUCONTROL_PSU_STATE_CHANGED
-            and self.psucontrol_enabled
         ):
             self._generate_psu_state(payload["isPSUOn"])
 

--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -200,6 +200,9 @@ class HomeassistantPlugin(
         self.on_print_progress("", "", 0)
         self._generate_connection_status()
 
+        if self.psucontrol_enabled:
+            self._generate_psu_state()
+
     def _get_mac_address(self):
         import uuid
 


### PR DESCRIPTION
This was created six months ago, but the PSUControl plugin was lacking events and helper functions. I have then added these to the plugin and created a PR, but it took a while for that was merged so I kind of forgot I still had to push this code.
This weekend I rebased my fork to your current code and re-added the PSUControl functionality.
In short: this will check if the PSUControl helpers are available and if so, it will publish a switch to HA for toggling the power supply.