### PR TITLE
Patch for Print Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OctoPrint-HomeAssistant
 
-Enable MQTT based discovery of your OctoPrint server with Home Assistant.
+Enable MQTT based discovery of one or more OctoPrint servers within Home Assistant.
 
 ## Setup
 
@@ -48,7 +48,7 @@ To use this example, you will need the custom components (available from [HACS](
 - [Stack in Card](https://github.com/custom-cards/stack-in-card)
 - [Bar Card](https://github.com/custom-cards/bar-card)
 - [Mini Graph Card](https://github.com/kalkih/mini-graph-card)
--
+
 ```yaml
 cards:
   - cards:
@@ -262,3 +262,34 @@ One user (thanks @SirGoodenough) has created a blueprint that will generate most
 If you would like to check that out, the link for that BluePrint is here:
 
 [🧯 Octoprint Additional Buttons Helper](https://github.com/SirGoodenough/HA_Blueprints/blob/master/Automations/Octoprint_Additional_Buttons_Helper.md)
+
+## Breaking Changes
+
+### Print Time Formatting < v3.5.6
+
+The time data that used to be sent to Home Assistant (octoprint-homeassistant > v3.6.3) had to be changed to allow for Print Time graphs. With this change, it means that the received value for Print Time, Print Time Left and Approximate Total Print Time is now in seconds. This will require formatting before being used in it's raw state. In a notification for example:
+
+```yaml
+service: notify.mobile_app_somedevice
+data:
+  title: Printing {{ states(`sensor.octoprint_print_file`) }}
+  message: >-
+    Your print has {{ timedelta(seconds=states(`sensor.octoprint_print_time_left`)|int(default=0)) }} left,
+    after {{ timedelta(seconds=states(`sensor.octoprint_print_time`)|int(default=0)) }}.
+    Current Z{{ states(`sensor.octoprint_current_z`) }}
+  data:
+    notification_icon: mdi:printer-3d
+```
+
+This new method allows you to format the time however you would like within Home Assistant.
+
+_It is possible to still use the old formatting for the time sensors by reading the attributes of some of the sensors._
+
+- Approximate Total Print Time:
+  `state_attr('sensor.octoprint_approximate_total_print_time', 'EstimatedPrintTimeFormatted')`
+
+- Print Time:
+  `state_attr('sensor.octoprint_print_progress', 'PrintTimeFormatted')`
+
+- Print Time Left:
+  `state_attr('sensor.octoprint_print_progress', 'PrintTimeLeftFormatted')`

--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -4,15 +4,11 @@ from __future__ import absolute_import
 import datetime
 import json
 import logging
-import os
 import re
-import threading
-import time
 
 import psutil
 import octoprint.plugin
-from octoprint.events import Events, eventManager
-from octoprint.server import user_permission
+from octoprint.events import Events
 from octoprint.settings import settings
 from octoprint.util import RepeatedTimer
 
@@ -351,8 +347,17 @@ class HomeassistantPlugin(
                 "name": _node_name + " Print Time",
                 "uniq_id": _node_id + "_PRINTING_T",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
-                "stat_cla": "measurement",
-                "val_tpl": "{{value_json.progress.printTimeFormatted}}",
+                "avty": [
+                    {
+                        "t": "~" + self._generate_topic("hassTopic", "printing"),
+                        "val_tpl": "{{'False' if not value_json.progress.printTime else 'True'}}",
+                        "pl_avail": "True",
+                        "pl_not_avail": "False",
+                    }
+                ],
+                "val_tpl": "{{value_json.progress.printTime}}",
+                "dev_cla": "duration",
+                "unit_of_meas": "s",
                 "device": _config_device,
                 "ic": "mdi:clock-start",
             },
@@ -365,8 +370,17 @@ class HomeassistantPlugin(
                 "name": _node_name + " Print Time Left",
                 "uniq_id": _node_id + "_PRINTING_E",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
-                "stat_cla": "measurement",
-                "val_tpl": "{{value_json.progress.printTimeLeftFormatted}}",
+                "avty": [
+                    {
+                        "t": "~" + self._generate_topic("hassTopic", "printing"),
+                        "val_tpl": "{{'False' if not value_json.progress.printTimeLeft else 'True'}}",
+                        "pl_avail": "True",
+                        "pl_not_avail": "False",
+                    }
+                ],
+                "val_tpl": "{{value_json.progress.printTimeLeft}}",
+                "dev_cla": "duration",
+                "unit_of_meas": "s",
                 "device": _config_device,
                 "ic": "mdi:clock-end",
             },
@@ -381,7 +395,17 @@ class HomeassistantPlugin(
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "json_attr_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "json_attr_tpl": "{{value_json.job|tojson}}",
-                "val_tpl": "{{value_json.job.estimatedPrintTimeFormatted}}",
+                "avty": [
+                    {
+                        "t": "~" + self._generate_topic("hassTopic", "printing"),
+                        "val_tpl": "{{'False' if not value_json.job.estimatedPrintTime else 'True'}}",
+                        "pl_avail": "True",
+                        "pl_not_avail": "False",
+                    },
+                ],
+                "val_tpl": "{{value_json.job.estimatedPrintTime}}",
+                "dev_cla": "duration",
+                "unit_of_meas": "s",
                 "device": _config_device,
             },
         )
@@ -393,8 +417,16 @@ class HomeassistantPlugin(
                 "name": _node_name + " Approximate Completion Time",
                 "uniq_id": _node_id + "_PRINTING_C",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
-                "stat_cla": "measurement",
-                "val_tpl": "{{'None' if not value_json.progress.printTimeLeft else (now() + timedelta(seconds=value_json.progress.printTimeLeft|int(default=0))).timestamp()|timestamp_custom('%b %d, %X')}}",
+                "avty": [
+                    {
+                        "t": "~" + self._generate_topic("hassTopic", "printing"),
+                        "val_tpl": "{{'False' if not value_json.progress.printTimeLeft else 'True'}}",
+                        "pl_avail": "True",
+                        "pl_not_avail": "False",
+                    },
+                ],
+                "val_tpl": "{{now() + timedelta(seconds=value_json.progress.printTimeLeft|int(default=0))}}",
+                "dev_cla": "timestamp",
                 "device": _config_device,
             },
         )
@@ -559,13 +591,22 @@ class HomeassistantPlugin(
         )
 
     def _generate_sensor(self, topic, values):
-        payload = {
-            "avty_t": "~" + self._generate_topic("lwTopic", ""),
+        payload={}
+        payload.update({
+            "avty": [],
+            "~": self._generate_topic("baseTopic", "", full=True),
+        })
+
+        # Add in set values
+        payload.update(values)
+
+        # Append default availability topic
+        payload["avty"].append({
+            "t": "~" + self._generate_topic("lwTopic", ""),
             "pl_avail": "connected",
             "pl_not_avail": "disconnected",
-            "~": self._generate_topic("baseTopic", "", full=True),
-        }
-        payload.update(values)
+        })
+
         self.mqtt_publish(topic, payload, allow_queueing=True)
 
     def _generate_device_config(
@@ -873,9 +914,13 @@ class HomeassistantPlugin(
                 "name": _node_name + " Cancel Print",
                 "uniq_id": _node_id + "_CANCEL",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "cancel"),
-                "avty_t": "~" + self._generate_topic("hassTopic", "is_printing"),
-                "pl_avail": "True",
-                "pl_not_avail": "False",
+                "avty": [
+                    {
+                        "t": "~" + self._generate_topic("hassTopic", "is_printing"),
+                        "pl_avail": "True",
+                        "pl_not_avail": "False",
+                    },
+                ],
                 "device": _config_device,
                 "ic": "mdi:cancel",
             },
@@ -895,9 +940,13 @@ class HomeassistantPlugin(
                 "uniq_id": _node_id + "_PAUSE",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "pause"),
                 "stat_t": "~" + self._generate_topic("hassTopic", "is_paused"),
-                "avty_t": "~" + self._generate_topic("hassTopic", "is_printing"),
-                "pl_avail": "True",
-                "pl_not_avail": "False",
+                "avty": [
+                    {
+                        "t": "~" + self._generate_topic("hassTopic", "is_printing"),
+                        "pl_avail": "True",
+                        "pl_not_avail": "False",
+                    },
+                ],
                 "pl_off": "False",
                 "pl_on": "True",
                 "device": _config_device,
@@ -1104,10 +1153,7 @@ class HomeassistantPlugin(
             )
 
 
-        if (
-            self.psucontrol_enabled and 
-            event == Events.PLUGIN_PSUCONTROL_PSU_STATE_CHANGED
-        ):
+        if self.psucontrol_enabled and event == Events.PLUGIN_PSUCONTROL_PSU_STATE_CHANGED:
             self._generate_psu_state(payload["isPSUOn"])
 
         if event == Events.CAPTURE_DONE:


### PR DESCRIPTION
This fixes problem #107, caused by the previous patch.

I have done some work to allow the Approximate Total Print Time, Print Time, and Print Time Left sensors to be displayed within graphs within the Home Assistant interface. I have changed Approximate Completion Time to use the built in Timestamp function within Home Assistant so it will now automatically display how long it left on your print once it has been started.

All of the time sensors now check to ensure that there is a valid value before changing from `unavailable` state. This means that if you do not have a print selected within Octoprint, the updated sensors will display `unavailable`.

Once a print has been selected within Octoprint, the Approximate Total Print Time will become available and will display the expected time for the print to complete.

Only once the print has started, will the Approximate Completion Time and Print Time Left become available with there actual values. Print Time is updated once the printer has actually started making progress through the print.

I hope this is a improvement for you all! Enjoy!

_The suggestion for using graphs was in Feature Request #97_
__I also did a little bit of tiding up of any unused imports__