### PR TITLE
Precise Print Progress Percentage

### DIFF
--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -324,9 +324,10 @@ class HomeassistantPlugin(
                 "uniq_id": _node_id + "_PRINTING_P",
                 "json_attr_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "json_attr_tpl": "{{value_json.progress|tojson}}",
-                "stat_t": "~" + self._generate_topic("progressTopic", "printing"),
+                "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "unit_of_meas": "%",
-                "val_tpl": "{{value_json.progress|float(0)}}",
+                "val_tpl": "{{value_json.progress.completion|float(0)}}",
+                "sug_dsp_prc": 2,
                 "device": _config_device,
             },
         )
@@ -1105,7 +1106,7 @@ class HomeassistantPlugin(
 
 
         if (
-            self.psucontrol_enabled and 
+            self.psucontrol_enabled and
             event == Events.PLUGIN_PSUCONTROL_PSU_STATE_CHANGED
         ):
             self._generate_psu_state(payload["isPSUOn"])

--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -326,7 +326,7 @@ class HomeassistantPlugin(
                 "json_attr_tpl": "{{value_json.progress|tojson}}",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "unit_of_meas": "%",
-                "val_tpl": "{{value_json.progress.completion|float(0)}}",
+                "val_tpl": "{{value_json.progress.completion|float(0)|round(4)}}",
                 "sug_dsp_prc": 2,
                 "device": _config_device,
             },


### PR DESCRIPTION
In this patch, I have added in a more precise display of the print progress percentage that is displayed within Home Assistant. The `suggested_display_precision` is set to `2` to allow for two decimal places on the percentage which is probably the sweet spot for accuracy.

Enjoy! :)