### PR TITLE
Fix entity names to avoid breaking change introduced in Home Assistant 2023.8

### DIFF
--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -266,7 +266,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/binary_sensor/" + _node_id + "_CONNECTED/config",
             values={
-                "name": _node_name + " Connected",
+                "name": "Connected",
                 "uniq_id": _node_id + "_CONNECTED",
                 "stat_t": "~" + self._generate_topic("hassTopic", "Connected"),
                 "pl_on": "Connected",
@@ -280,7 +280,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/binary_sensor/" + _node_id + "_PRINTING/config",
             values={
-                "name": _node_name + " Printing",
+                "name": "Printing",
                 "uniq_id": _node_id + "_PRINTING",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "pl_on": "True",
@@ -294,7 +294,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_EVENT/config",
             values={
-                "name": _node_name + " Last Event",
+                "name": "Last event",
                 "uniq_id": _node_id + "_EVENT",
                 "stat_t": "~" + self._generate_topic("eventTopic", "+"),
                 "val_tpl": "{{value_json._event}}",
@@ -306,7 +306,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_S/config",
             values={
-                "name": _node_name + " Print Status",
+                "name": "Print status",
                 "uniq_id": _node_id + "_PRINTING_S",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "json_attr_t": "~" + self._generate_topic("hassTopic", "printing"),
@@ -320,7 +320,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_P/config",
             values={
-                "name": _node_name + " Print Progress",
+                "name": "Print progress",
                 "uniq_id": _node_id + "_PRINTING_P",
                 "json_attr_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "json_attr_tpl": "{{value_json.progress|tojson}}",
@@ -335,7 +335,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_F/config",
             values={
-                "name": _node_name + " Print File",
+                "name": "Print file",
                 "uniq_id": _node_id + "_PRINTING_F",
                 "stat_t": "~" + self._generate_topic("progressTopic", "printing"),
                 "val_tpl": "{{value_json.path}}",
@@ -348,7 +348,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_T/config",
             values={
-                "name": _node_name + " Print Time",
+                "name": "Print time",
                 "uniq_id": _node_id + "_PRINTING_T",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "stat_cla": "measurement",
@@ -362,7 +362,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_E/config",
             values={
-                "name": _node_name + " Print Time Left",
+                "name": "Print time left",
                 "uniq_id": _node_id + "_PRINTING_E",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "stat_cla": "measurement",
@@ -376,7 +376,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_ETA/config",
             values={
-                "name": _node_name + " Approximate Total Print Time",
+                "name": "Approximate total print time",
                 "uniq_id": _node_id + "_PRINTING_ETA",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "json_attr_t": "~" + self._generate_topic("hassTopic", "printing"),
@@ -390,7 +390,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_C/config",
             values={
-                "name": _node_name + " Approximate Completion Time",
+                "name": "Approximate completion time",
                 "uniq_id": _node_id + "_PRINTING_C",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "stat_cla": "measurement",
@@ -403,7 +403,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_Z/config",
             values={
-                "name": _node_name + " Current Z",
+                "name": "Current Z",
                 "uniq_id": _node_id + "_PRINTING_Z",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "unit_of_meas": "mm",
@@ -417,7 +417,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_SLICING_P/config",
             values={
-                "name": _node_name + " Slicing Progress",
+                "name": "Slicing progress",
                 "uniq_id": _node_id + "_SLICING_P",
                 "stat_t": "~" + self._generate_topic("progressTopic", "slicing"),
                 "unit_of_meas": "%",
@@ -430,7 +430,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_SLICING_F/config",
             values={
-                "name": _node_name + " Slicing File",
+                "name": "Slicing file",
                 "uniq_id": _node_id + "_SLICING_F",
                 "stat_t": "~" + self._generate_topic("progressTopic", "slicing"),
                 "val_tpl": "{{value_json.source_path}}",
@@ -450,7 +450,7 @@ class HomeassistantPlugin(
                 + str(x)
                 + "/config",
                 values={
-                    "name": _node_name + " Tool " + str(x) + " Temperature",
+                    "name": "Tool " + str(x) + " temperature",
                     "uniq_id": _node_id + "_TOOL" + str(x),
                     "stat_t": "~"
                     + self._generate_topic("temperatureTopic", "tool" + str(x)),
@@ -470,7 +470,7 @@ class HomeassistantPlugin(
                 + "_TARGET"
                 + "/config",
                 values={
-                    "name": _node_name + " Tool " + str(x) + " Target",
+                    "name": "Tool " + str(x) + " target",
                     "uniq_id": _node_id + "_TOOL" + str(x) + "_TARGET",
                     "stat_t": "~"
                     + self._generate_topic("temperatureTopic", "tool" + str(x)),
@@ -486,7 +486,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_BED/config",
             values={
-                "name": _node_name + " Bed Temperature",
+                "name": "Bed temperature",
                 "uniq_id": _node_id + "_BED",
                 "stat_t": "~" + self._generate_topic("temperatureTopic", "bed"),
                 "unit_of_meas": "°C",
@@ -499,7 +499,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_BED_TARGET/config",
             values={
-                "name": _node_name + " Bed Target",
+                "name": "Bed target",
                 "uniq_id": _node_id + "_BED_TARGET",
                 "stat_t": "~" + self._generate_topic("temperatureTopic", "bed"),
                 "unit_of_meas": "°C",
@@ -516,7 +516,7 @@ class HomeassistantPlugin(
             self._generate_sensor(
                 topic=_discovery_topic + "/sensor/" + _node_id + "_CHAMBER/config",
                 values={
-                    "name": _node_name + " Chamber Temperature",
+                    "name": "Chamber temperature",
                     "uniq_id": _node_id + "_CHAMBER",
                     "stat_t": "~" + self._generate_topic("temperatureTopic", "chamber"),
                     "unit_of_meas": "°C",
@@ -532,7 +532,7 @@ class HomeassistantPlugin(
                 + _node_id
                 + "_CHAMBER_TARGET/config",
                 values={
-                    "name": _node_name + " Chamber Target",
+                    "name": "Chamber target",
                     "uniq_id": _node_id + "_CHAMBER_TARGET",
                     "stat_t": "~" + self._generate_topic("temperatureTopic", "chamber"),
                     "unit_of_meas": "°C",
@@ -547,7 +547,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic="homeassistant/sensor/" + _node_id + "_SOC/config",
             values={
-                "name": _node_name + " SoC Temperature",
+                "name": "SoC temperature",
                 "uniq_id": _node_id + "_SOC",
                 "stat_t": "~" + self._generate_topic("temperatureTopic", "soc"),
                 "unit_of_meas": "°C",
@@ -829,7 +829,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/switch/" + _node_id + "_CONNECT/config",
             values={
-                "name": _node_name + " Connect to printer",
+                "name": "Connect to printer",
                 "uniq_id": _node_id + "_CONNECT",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "connect"),
                 "stat_t": self._generate_topic("hassTopic", "Connected", full=True),
@@ -852,7 +852,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_STOP/config",
             values={
-                "name": _node_name + " Emergency Stop",
+                "name": "Emergency stop",
                 "uniq_id": _node_id + "_STOP",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "stop"),
                 "device": _config_device,
@@ -870,7 +870,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_CANCEL/config",
             values={
-                "name": _node_name + " Cancel Print",
+                "name": "Cancel print",
                 "uniq_id": _node_id + "_CANCEL",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "cancel"),
                 "avty_t": "~" + self._generate_topic("hassTopic", "is_printing"),
@@ -891,7 +891,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/switch/" + _node_id + "_PAUSE/config",
             values={
-                "name": _node_name + " Pause Print",
+                "name": "Pause print",
                 "uniq_id": _node_id + "_PAUSE",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "pause"),
                 "stat_t": "~" + self._generate_topic("hassTopic", "is_paused"),
@@ -923,7 +923,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_SHUTDOWN/config",
             values={
-                "name": _node_name + " Shutdown System",
+                "name": "Shutdown system",
                 "uniq_id": _node_id + "_SHUTDOWN",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "shutdown"),
                 "device": _config_device,
@@ -934,7 +934,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_REBOOT/config",
             values={
-                "name": _node_name + " Reboot System",
+                "name": "Reboot system",
                 "uniq_id": _node_id + "_REBOOT",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "reboot"),
                 "device": _config_device,
@@ -945,7 +945,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_RESTART/config",
             values={
-                "name": _node_name + " Restart Server",
+                "name": "Restart server",
                 "uniq_id": _node_id + "_RESTART",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "restart"),
                 "device": _config_device,
@@ -964,7 +964,7 @@ class HomeassistantPlugin(
             self._generate_sensor(
                 topic=_discovery_topic + "/switch/" + _node_id + "_PSU/config",
                 values={
-                    "name": _node_name + " PSU",
+                    "name": "PSU",
                     "uniq_id": _node_id + "_PSU",
                     "cmd_t": "~" + self._generate_topic("controlTopic", "psu"),
                     "stat_t": "~" + self._generate_topic("hassTopic", "psu_on"),
@@ -989,7 +989,7 @@ class HomeassistantPlugin(
                 + _node_id
                 + "_CAMERA_SNAPSHOT/config",
                 values={
-                    "name": _node_name + " Camera snapshot",
+                    "name": "Camera snapshot",
                     "uniq_id": _node_id + "_CAMERA_SNAPSHOT",
                     "cmd_t": "~"
                     + self._generate_topic("controlTopic", "camera_snapshot"),


### PR DESCRIPTION
A change was implemented in Home Assistant 2023.8 that doesn't allow for entity names to be prefixed by a string that is equivalent to the device name. The device name is `OctoPrint`. All entity names are currently prefixed with this device name (e.g., `OctoPrint Emergency stop`). Starting in Home Assistant 2023.8, a warning is logged + repair issue raised for each MQTT entity that is using this naming convention:

```
Logger: homeassistant.components.mqtt.mixins
Source: components/mqtt/mixins.py:294
Integration: MQTT (documentation, issues)
First occurred: 3:16:54 PM (30 occurrences)
Last logged: 3:16:54 PM

MQTT entity name starts with the device name in your config {'availability_topic': 'octoprint/mqtt', 'payload_available': 'connected', 'payload_not_available': 'disconnected', 'name': 'OctoPrint Emergency Stop', 'unique_id': 'CA6944_STOP', 'command_topic': 'octoprint/hassControl/stop', 'device': {'identifiers': ['CA6944'], 'name': 'OctoPrint', 'manufacturer': 'Clifford Roche', 'model': 'HomeAssistant Discovery for OctoPrint', 'sw_version': 'HomeAssistant Discovery for OctoPrint 3.6.5', 'connections': []}, 'icon': 'mdi:alert-octagon', 'qos': 0, 'retain': False, 'encoding': 'utf-8', 'enabled_by_default': True, 'payload_press': 'PRESS', 'availability_mode': 'latest'}, this is not expected. Please correct your configuration. The device name prefix will be stripped off the entity name and becomes 'Emergency Stop'
MQTT entity name starts with the device name in your config {'availability_topic': 'octoprint/hass/is_printing', 'payload_available': 'True', 'payload_not_available': 'False', 'name': 'OctoPrint Cancel Print', 'unique_id': 'CA6944_CANCEL', 'command_topic': 'octoprint/hassControl/cancel', 'device': {'identifiers': ['CA6944'], 'name': 'OctoPrint', 'manufacturer': 'Clifford Roche', 'model': 'HomeAssistant Discovery for OctoPrint', 'sw_version': 'HomeAssistant Discovery for OctoPrint 3.6.5', 'connections': []}, 'icon': 'mdi:cancel', 'qos': 0, 'retain': False, 'encoding': 'utf-8', 'enabled_by_default': True, 'payload_press': 'PRESS', 'availability_mode': 'latest'}, this is not expected. Please correct your configuration. The device name prefix will be stripped off the entity name and becomes 'Cancel Print'
MQTT entity name starts with the device name in your config {'availability_topic': 'octoprint/mqtt', 'payload_available': 'connected', 'payload_not_available': 'disconnected', 'name': 'OctoPrint Shutdown System', 'unique_id': 'CA6944_SHUTDOWN', 'command_topic': 'octoprint/hassControl/shutdown', 'device': {'identifiers': ['CA6944'], 'name': 'OctoPrint', 'manufacturer': 'Clifford Roche', 'model': 'HomeAssistant Discovery for OctoPrint', 'sw_version': 'HomeAssistant Discovery for OctoPrint 3.6.5', 'connections': []}, 'icon': 'mdi:power', 'qos': 0, 'retain': False, 'encoding': 'utf-8', 'enabled_by_default': True, 'payload_press': 'PRESS', 'availability_mode': 'latest'}, this is not expected. Please correct your configuration. The device name prefix will be stripped off the entity name and becomes 'Shutdown System'
MQTT entity name starts with the device name in your config {'availability_topic': 'octoprint/mqtt', 'payload_available': 'connected', 'payload_not_available': 'disconnected', 'name': 'OctoPrint Reboot System', 'unique_id': 'CA6944_REBOOT', 'command_topic': 'octoprint/hassControl/reboot', 'device': {'identifiers': ['CA6944'], 'name': 'OctoPrint', 'manufacturer': 'Clifford Roche', 'model': 'HomeAssistant Discovery for OctoPrint', 'sw_version': 'HomeAssistant Discovery for OctoPrint 3.6.5', 'connections': []}, 'icon': 'mdi:restart-alert', 'qos': 0, 'retain': False, 'encoding': 'utf-8', 'enabled_by_default': True, 'payload_press': 'PRESS', 'availability_mode': 'latest'}, this is not expected. Please correct your configuration. The device name prefix will be stripped off the entity name and becomes 'Reboot System'
MQTT entity name starts with the device name in your config {'availability_topic': 'octoprint/mqtt', 'payload_available': 'connected', 'payload_not_available': 'disconnected', 'name': 'OctoPrint Restart Server', 'unique_id': 'CA6944_RESTART', 'command_topic': 'octoprint/hassControl/restart', 'device': {'identifiers': ['CA6944'], 'name': 'OctoPrint', 'manufacturer': 'Clifford Roche', 'model': 'HomeAssistant Discovery for OctoPrint', 'sw_version': 'HomeAssistant Discovery for OctoPrint 3.6.5', 'connections': []}, 'icon': 'mdi:restart', 'qos': 0, 'retain': False, 'encoding': 'utf-8', 'enabled_by_default': True, 'payload_press': 'PRESS', 'availability_mode': 'latest'}, this is not expected. Please correct your configuration. The device name prefix will be stripped off the entity name and becomes 'Restart Server'
```


This PR solves that issue by removing the prefix. I have also edited the names of the entities to follow Home Assistant entity naming guidelines. The first word in the entity name should be capitalized while words that follow should be lowercase (unless it is a brand or the word is capitalized in normal writing). For example `Print Time Left` has been changed to `Print time left`. 